### PR TITLE
Turn back cache sizes to default for sqlite

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -44,7 +44,6 @@ const ORMModules = [
             database: './DB/public-pool.sqlite',
             synchronize: true,
             autoLoadEntities: true,
-            cache: true,
             logging: false,
             enableWAL: true,
             busyTimeout: 30 * 1000,

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -20,13 +20,14 @@ export class AppService implements OnModuleInit {
         // if (process.env.NODE_APP_INSTANCE == '0') {
         //     await this.dataSource.query(`VACUUM;`);
         // }
+
         //https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
-        //500 MB DB cache
-        await this.dataSource.query(`PRAGMA cache_size = -500000;`);
+        // //500 MB DB cache
+        // await this.dataSource.query(`PRAGMA cache_size = -500000;`);
         //Normal is still completely corruption safe in WAL mode, and means only WAL checkpoints have to wait for FSYNC. 
         await this.dataSource.query(`PRAGMA synchronous = off;`);
-        //6Gb
-        await this.dataSource.query(`PRAGMA mmap_size = 6000000000;`);
+        // //6Gb
+        // await this.dataSource.query(`PRAGMA mmap_size = 6000000000;`);
     }
 
     @Interval(1000 * 60 * 60)


### PR DESCRIPTION
Turning the cache back to defaults so that small devices like the pi can run public-pool. This was an attempt to runs thousands of clients until I created the postgres branch. 